### PR TITLE
Prevents dgreen error on darwin systems

### DIFF
--- a/core/colors.py
+++ b/core/colors.py
@@ -11,7 +11,7 @@ if checkplatform.startswith("Windows-10") and int(platform.version().split(".")[
     colors = True
     os.system('')   # Enables the ANSI
 if not colors:
-    end = red = white = green = yellow = run = bad = good = info = que = ''
+    end = red = white = green = dgreen = yellow = run = bad = good = info = que = ''
 else:
     white = '\033[97m'
     green = '\033[92m'


### PR DESCRIPTION
$ python3 striker.py w2ogroup.com
Traceback (most recent call last):
  File "striker.py", line 18, in <module>
    from core.colors import red, white, end, green, dgreen, info, good, bad, run, red_line