### PR TITLE
fixed a line break in requester.py and findsubdomains.py ... changed …

### DIFF
--- a/core/requester.py
+++ b/core/requester.py
@@ -18,8 +18,7 @@ def requester(url, data=None, GET=True):
         if 'User-Agent' not in headers:
             headers['User-Agent'] = random.choice(user_agents)
     if GET:
-        response = requests.get(
-            url, params=data, headers=headers, verify=False)
+        response = requests.get(url, params=data, headers=headers, verify=False)
     else:
         response = requests.post(url, data=data, headers=headers, verify=False)
     return response

--- a/modules/findsubdomains.py
+++ b/modules/findsubdomains.py
@@ -3,7 +3,6 @@ import sys
 from core.requester import requester
 
 def findsubdomains(host):
-    response = requester('https://findsubdomains.com/subdomains-of/' +
-                   host).text
-    matches = re.finditer(r'(?s)<div class="domains js-domain-name">(.*?)</div>', response)
+    response = requester('https://viewdns.info/dnsrecord/?domain=' + host).text
+    matches = re.finditer(r'(?s)<tr>(/n)<td>(.*?)</td>', response)
     return [match.group(1).lstrip('\n').rstrip(' ').lstrip(' ') for match in matches]


### PR DESCRIPTION
…findsubdomains.py to point at a host that still exists.. but, unfortunately that host does not find sub domains.. i have to take my lady to the airport and just wanted to get the thing running real quick.. i will update it with soem more appropriate dns toolkit website.. right now it uses viewdns.info simply because the request and response was similar to what the script already expected

on second thought (and after browsing the source for several websites and having them beg people to stop abusing their service and simply purchase and api key.. perhaps we just remove this feature of Striker (or bundle a rudimentary one in, or recursively clone one in).. I'd favor the approach to allow the user to choose a single host or read hosts from a file (where they can have a file of subdomains, if that's their agenda)... your call